### PR TITLE
change: exports for go to definition

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -22,8 +22,8 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"types": "./dist/index.d.ts",
-			"default": "./dist/index.js"
+			"types": "./dist/integration.d.ts",
+			"default": "./dist/integration.js"
 		}
 	},
 	"files": ["dist"],

--- a/package/src/index.ts
+++ b/package/src/index.ts
@@ -1,3 +1,0 @@
-import { integration } from "./integration.js";
-
-export default integration;

--- a/package/src/integration.ts
+++ b/package/src/integration.ts
@@ -1,6 +1,6 @@
 import { defineIntegration } from "astro-integration-kit";
 
-export const integration = defineIntegration({
+export default defineIntegration({
 	name: "package-name",
 	setup() {
 		return {};


### PR DESCRIPTION
When exports `index.*` in `package.json` with: 
```ts
import { integration } from "./integration.js";

export default integration;
```

`tsup` will generate this `index.d.ts` and Go to definition will go this file.
```ts
import { integration } from './integration.js';
import 'astro';


export { integration as default };
```

But for me, I think it should jump to `integration.d.ts`, so I made this PR.
`integration.d.ts` is look like:
```ts
import * as astro from 'astro';

declare const integration: () => astro.AstroIntegration;

export { integration };
```